### PR TITLE
Updated build script path in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,8 +323,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Make dist/install.sh
-        run: make dist/install.sh
+      - name: Make install script
+        run: make out/install.sh
 
       - name: Test
         run: make .test/install_script

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
         uses: tj-actions/changed-files@v44
         with:
           files: |
+            .github/workflows/**
             provider/cmd/provisioner/install.sh
 
   goreleaser:


### PR DESCRIPTION
The CI workflow has been updated to reflect changes in the build script's location. The 'make' command now points to 'out/install.sh' instead of 'dist/install.sh'. This change also affects the test command, ensuring it aligns with the new script location.