### PR TITLE
Updated Makefile and install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ buf.lock: $(BUF_CONFIG)
 	cd tests/sdk/$* && go test -v -count=1 -cover -timeout 2h ./...
 	@touch $@
 
-.test/install_script: out/install.sh
+.test/install_script: out/install.sh $(PROVIDER_PATH)/cmd/provisioner/baremetal-provisioner.service Makefile
 	DEV_MODE=true INSTALL_DIR=${WORKING_DIR}/bin $<
 	@touch $@
 

--- a/provider/cmd/provisioner/baremetal-provisioner.service
+++ b/provider/cmd/provisioner/baremetal-provisioner.service
@@ -5,7 +5,6 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-EnvironmentFile=$VARS_FILE
 ExecStart=$PROVISIONER_BIN \
 	--address $LISTEN_ADDRESS \
 	--network $LISTEN_NETWORK \


### PR DESCRIPTION
The Makefile has been updated to include the provisioner service in the test/install_script target. The EnvironmentFile directive was removed from the baremetal-provisioner.service file, and environment variables are now exported directly in the install.sh script. This simplifies the process of setting up environment variables for the provisioner service. Additionally, unnecessary steps were removed from install.sh, such as creating a temporary vars file and ensuring a config directory exists.
