### PR TITLE
Let Pulumi handle the replace-on-update logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Pulumi.*.yaml
 
 .make/
 .test/
+*.test
 .envrc
 
 # Build Artifacts

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ $(GO_MODULES:%=.make/tidy/%): .make/tidy/%: $(addprefix %/,go.mod go.sum)
 		--out ${WORKING_DIR}/examples/$*
 	@touch $@
 
+export GRPC_GO_LOG_SEVERITY_LEVEL ?=
 TEST_FLAGS ?=
 
 .test/provider: .make/provisioner_test_docker_build

--- a/provider/pkg/provider/cmd/chmod.go
+++ b/provider/pkg/provider/cmd/chmod.go
@@ -84,8 +84,10 @@ func (Chmod) Delete(ctx context.Context, id string, props ChmodState) error {
 		return fmt.Errorf("chmod: %w", err)
 	}
 
+	// TODO: Provisioner: Read current perms before modifying them
 	return nil
 }
 
 var _ = (infer.CustomCreate[CommandArgs[ChmodArgs], ChmodState])((*Chmod)(nil))
 var _ = (infer.CustomUpdate[CommandArgs[ChmodArgs], ChmodState])((*Chmod)(nil))
+var _ = (infer.CustomDelete[MkdirState])((*Mkdir)(nil))

--- a/provider/pkg/provider/cmd/command.go
+++ b/provider/pkg/provider/cmd/command.go
@@ -103,18 +103,13 @@ func (s *CommandState[T]) Create(ctx context.Context, inputs CommandArgs[T], pre
 	return nil
 }
 
-func (s *CommandState[T]) Diff(ctx context.Context, inputs CommandArgs[T]) (provider.DiffResponse, error) {
+func (s *CommandState[T]) Diff(ctx context.Context, inputs CommandArgs[T]) (map[string]provider.PropertyDiff, error) {
 	diff := map[string]provider.PropertyDiff{}
-
 	if !slices.Equal(s.Triggers, inputs.Triggers) {
 		diff["triggers"] = provider.PropertyDiff{Kind: provider.Update}
 	}
 
-	return provider.DiffResponse{
-		DeleteBeforeReplace: true,
-		HasChanges:          len(diff) > 0,
-		DetailedDiff:        diff,
-	}, nil
+	return diff, nil
 }
 
 func (s *CommandState[T]) Update(ctx context.Context, inputs CommandArgs[T], preview bool) (CommandState[T], error) {

--- a/provider/pkg/provider/cmd/mkdir.go
+++ b/provider/pkg/provider/cmd/mkdir.go
@@ -71,3 +71,4 @@ func (Mkdir) Delete(ctx context.Context, id string, props MkdirState) error {
 
 var _ = (infer.CustomCreate[CommandArgs[MkdirArgs], MkdirState])((*Mkdir)(nil))
 var _ = (infer.CustomUpdate[CommandArgs[MkdirArgs], MkdirState])((*Mkdir)(nil))
+var _ = (infer.CustomDelete[MkdirState])((*Mkdir)(nil))

--- a/provider/pkg/provider/cmd/mktemp.go
+++ b/provider/pkg/provider/cmd/mktemp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	provider "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 	pb "github.com/unmango/pulumi-baremetal/gen/go/unmango/baremetal/v1alpha1"
 )
@@ -62,6 +63,52 @@ func (Mktemp) Create(ctx context.Context, name string, inputs CommandArgs[Mktemp
 	return name, state, nil
 }
 
+// Diff implements infer.CustomDiff.
+func (Mktemp) Diff(ctx context.Context, id string, olds MktempState, news CommandArgs[MktempArgs]) (provider.DiffResponse, error) {
+	diff, err := olds.Diff(ctx, news)
+	if err != nil {
+		return provider.DiffResponse{}, fmt.Errorf("mv: %w", err)
+	}
+
+	if news.Args.Directory != olds.Args.Directory {
+		diff["args.directory"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.DryRun != olds.Args.DryRun {
+		diff["args.destination"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Quiet != olds.Args.Quiet {
+		diff["args.quiet"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Suffix != olds.Args.Suffix {
+		diff["args.suffix"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.T != olds.Args.T {
+		diff["args.t"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Template != olds.Args.Template {
+		diff["args.template"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.TmpDir != olds.Args.TmpDir {
+		diff["args.tmpDir"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Directory != olds.Args.Directory {
+		diff["args.suffix"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	return provider.DiffResponse{
+		DeleteBeforeReplace: true,
+		HasChanges:          len(diff) > 0,
+		DetailedDiff:        diff,
+	}, nil
+}
+
 // Update implements infer.CustomUpdate.
 func (Mktemp) Update(ctx context.Context, id string, olds MktempState, news CommandArgs[MktempArgs], preview bool) (MktempState, error) {
 	state, err := olds.Update(ctx, news, preview)
@@ -82,5 +129,6 @@ func (Mktemp) Delete(ctx context.Context, id string, props MktempState) error {
 }
 
 var _ = (infer.CustomCreate[CommandArgs[MktempArgs], MktempState])((*Mktemp)(nil))
+var _ = (infer.CustomDiff[CommandArgs[MktempArgs], MktempState])((*Mktemp)(nil))
 var _ = (infer.CustomUpdate[CommandArgs[MktempArgs], MktempState])((*Mktemp)(nil))
 var _ = (infer.CustomDelete[MktempState])((*Mktemp)(nil))

--- a/provider/pkg/provider/cmd/mv.go
+++ b/provider/pkg/provider/cmd/mv.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"slices"
 
+	provider "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 	pb "github.com/unmango/pulumi-baremetal/gen/go/unmango/baremetal/v1alpha1"
 )
@@ -88,6 +90,64 @@ func (Mv) Create(ctx context.Context, name string, inputs CommandArgs[MvArgs], p
 	return name, state, nil
 }
 
+// Diff implements infer.CustomDiff.
+func (Mv) Diff(ctx context.Context, id string, olds MvState, news CommandArgs[MvArgs]) (provider.DiffResponse, error) {
+	diff, err := olds.Diff(ctx, news)
+	if err != nil {
+		return provider.DiffResponse{}, fmt.Errorf("mv: %w", err)
+	}
+
+	if news.Args.Backup != olds.Args.Backup {
+		diff["args.backup"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Destination != olds.Args.Destination {
+		diff["args.destination"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Directory != olds.Args.Directory {
+		diff["args.directory"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Force != olds.Args.Force {
+		diff["args.force"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.NoClobber != olds.Args.NoClobber {
+		diff["args.noClobber"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.NoTargetDirectory != olds.Args.NoTargetDirectory {
+		diff["args.noTargetDirectory"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if !slices.Equal(news.Args.Source, olds.Args.Source) {
+		diff["args.source"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.StripTrailingSlashes != olds.Args.StripTrailingSlashes {
+		diff["args.stripTrailingSlashes"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Suffix != olds.Args.Suffix {
+		diff["args.suffix"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.TargetDirectory != olds.Args.TargetDirectory {
+		diff["args.targetDirectory"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Update != olds.Args.Update {
+		diff["args.update"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	return provider.DiffResponse{
+		DeleteBeforeReplace: true,
+		HasChanges:          len(diff) > 0,
+		DetailedDiff:        diff,
+	}, nil
+}
+
 // Update implements infer.CustomUpdate.
 func (Mv) Update(ctx context.Context, id string, olds MvState, news CommandArgs[MvArgs], preview bool) (MvState, error) {
 	state, err := olds.Update(ctx, news, preview)
@@ -108,4 +168,6 @@ func (Mv) Delete(ctx context.Context, id string, props MvState) error {
 }
 
 var _ = (infer.CustomCreate[CommandArgs[MvArgs], MvState])((*Mv)(nil))
+var _ = (infer.CustomDiff[CommandArgs[MvArgs], MvState])((*Mv)(nil))
 var _ = (infer.CustomUpdate[CommandArgs[MvArgs], MvState])((*Mv)(nil))
+var _ = (infer.CustomDelete[MvState])((*Mv)(nil))

--- a/provider/pkg/provider/cmd/tar.go
+++ b/provider/pkg/provider/cmd/tar.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"slices"
 
+	provider "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 	pb "github.com/unmango/pulumi-baremetal/gen/go/unmango/baremetal/v1alpha1"
 )
@@ -161,6 +163,92 @@ func (Tar) Create(ctx context.Context, name string, inputs CommandArgs[TarArgs],
 	return name, state, nil
 }
 
+// Diff implements infer.CustomDiff.
+func (Tar) Diff(ctx context.Context, id string, olds TarState, news CommandArgs[TarArgs]) (provider.DiffResponse, error) {
+	diff, err := olds.Diff(ctx, news)
+	if err != nil {
+		return provider.DiffResponse{}, fmt.Errorf("rm: %w", err)
+	}
+
+	if news.Args.Append != olds.Args.Append {
+		diff["args.append"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if !slices.Equal(news.Args.Args, olds.Args.Args) { // lol
+		diff["args.args"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Bzip2 != olds.Args.Bzip2 {
+		diff["args.bzip2"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Create != olds.Args.Create {
+		diff["args.create"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Delete != olds.Args.Delete {
+		diff["args.delete"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Diff != olds.Args.Diff {
+		diff["args.diff"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.ExcludeVcs != olds.Args.ExcludeVcs {
+		diff["args.excludeVcs"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.ExcludeVcsIgnores != olds.Args.ExcludeVcsIgnores {
+		diff["args.excludeVcsIgnoes"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Extract != olds.Args.Extract {
+		diff["args.extract"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Gzip != olds.Args.Gzip {
+		diff["args.gzip"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.IgnoreCommandError != olds.Args.IgnoreCommandError {
+		diff["args.ignoreCommandError"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.NoOverwriteDir != olds.Args.OverwriteDir {
+		diff["args.noOverwriteDir"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.RemoveFiles != olds.Args.RemoveFiles {
+		diff["args.removeFiles"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Directory != olds.Args.Directory {
+		diff["args.directory"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Exclude != olds.Args.Exclude {
+		diff["args.exclude"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.File != olds.Args.File {
+		diff["args.file"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.StripComponents != olds.Args.StripComponents {
+		diff["args.stripComponents"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Transform != olds.Args.Transform {
+		diff["args.transform"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	return provider.DiffResponse{
+		DeleteBeforeReplace: true,
+		HasChanges:          len(diff) > 0,
+		DetailedDiff:        diff,
+	}, nil
+}
+
 // Update implements infer.CustomUpdate.
 func (Tar) Update(ctx context.Context, id string, olds TarState, news CommandArgs[TarArgs], preview bool) (TarState, error) {
 	state, err := olds.Update(ctx, news, preview)
@@ -181,5 +269,6 @@ func (Tar) Delete(ctx context.Context, id string, props TarState) error {
 }
 
 var _ = (infer.CustomCreate[CommandArgs[TarArgs], TarState])((*Tar)(nil))
+var _ = (infer.CustomDiff[CommandArgs[TarArgs], TarState])((*Tar)(nil))
 var _ = (infer.CustomUpdate[CommandArgs[TarArgs], TarState])((*Tar)(nil))
 var _ = (infer.CustomDelete[TarState])((*Tar)(nil))

--- a/provider/pkg/provider/cmd/wget.go
+++ b/provider/pkg/provider/cmd/wget.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"slices"
 
+	provider "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 	pb "github.com/unmango/pulumi-baremetal/gen/go/unmango/baremetal/v1alpha1"
 )
@@ -152,6 +154,52 @@ func (Wget) Create(ctx context.Context, name string, inputs CommandArgs[WgetArgs
 	return name, state, nil
 }
 
+// Diff implements infer.CustomDiff.
+func (Wget) Diff(ctx context.Context, id string, olds WgetState, news CommandArgs[WgetArgs]) (provider.DiffResponse, error) {
+	diff, err := olds.Diff(ctx, news)
+	if err != nil {
+		return provider.DiffResponse{}, fmt.Errorf("wget: %w", err)
+	}
+
+	if !slices.Equal(news.Args.Urls, olds.Args.Urls) {
+		diff["args.urls"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Quiet != olds.Args.Quiet {
+		diff["args.quiet"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Base != olds.Args.Base {
+		diff["args.base"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.DirectoryPrefix != olds.Args.DirectoryPrefix {
+		diff["args.directoryPrefix"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.ForceDirectories != olds.Args.ForceDirectories {
+		diff["args.foreceDirectories"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.OutputFile != olds.Args.OutputFile {
+		diff["args.outputFile"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.OutputDocument != olds.Args.OutputDocument {
+		diff["args.outputDocument"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	if news.Args.Timestamping != olds.Args.Timestamping {
+		diff["args.timestamping"] = provider.PropertyDiff{Kind: provider.UpdateReplace}
+	}
+
+	return provider.DiffResponse{
+		DeleteBeforeReplace: true,
+		HasChanges:          len(diff) > 0,
+		DetailedDiff:        diff,
+	}, nil
+}
+
 // Update implements infer.CustomUpdate.
 func (Wget) Update(ctx context.Context, id string, olds WgetState, news CommandArgs[WgetArgs], preview bool) (WgetState, error) {
 	state, err := olds.Update(ctx, news, preview)
@@ -172,5 +220,6 @@ func (Wget) Delete(ctx context.Context, id string, props WgetState) error {
 }
 
 var _ = (infer.CustomCreate[CommandArgs[WgetArgs], WgetState])((*Wget)(nil))
+var _ = (infer.CustomDiff[CommandArgs[WgetArgs], WgetState])((*Wget)(nil))
 var _ = (infer.CustomUpdate[CommandArgs[WgetArgs], WgetState])((*Wget)(nil))
 var _ = (infer.CustomDelete[WgetState])((*Wget)(nil))

--- a/provider/pkg/provisioner/cmd/service.go
+++ b/provider/pkg/provisioner/cmd/service.go
@@ -105,22 +105,6 @@ func (s *service) Create(ctx context.Context, req *pb.CreateRequest) (res *pb.Cr
 func (s *service) Update(ctx context.Context, req *pb.UpdateRequest) (res *pb.UpdateResponse, err error) {
 	log := s.Log.With("op", "update", "create", req.Create)
 
-	var delete *pb.DeleteResponse
-	toDelete := req.Create.CreatedFiles
-	toMove := req.Create.MovedFiles
-	if len(toDelete) > 0 || len(toMove) > 0 {
-		delete, err = s.Delete(ctx, &pb.DeleteRequest{
-			Create:  req.Create,
-			Updates: []*pb.Operation{}, // TODO
-		})
-	} else {
-		log.InfoContext(ctx, "nothing to delete")
-	}
-	if err != nil {
-		log.ErrorContext(ctx, "failed performing delete", "err", err)
-		return nil, fmt.Errorf("failed deleting: %w", err)
-	}
-
 	create, err := s.Create(ctx, &pb.CreateRequest{
 		Command:       req.Command,
 		ExpectCreated: req.ExpectCreated,
@@ -135,7 +119,7 @@ func (s *service) Update(ctx context.Context, req *pb.UpdateRequest) (res *pb.Up
 		Result:       create.Result,
 		CreatedFiles: create.CreatedFiles,
 		MovedFiles:   create.MovedFiles,
-		Deletes:      delete.Commands,
+		Deletes:      []*pb.Operation{},
 	}, nil
 }
 

--- a/tests/lifecycle_test.go
+++ b/tests/lifecycle_test.go
@@ -171,8 +171,8 @@ var _ = Describe("Command Resources", func() {
 		It("should complete a full lifecycle", func(ctx context.Context) {
 			run(server, test)
 
-			Expect(provisioner).To(ContainFile(ctx, file))
 			Expect(provisioner).NotTo(ContainFile(ctx, firstFile))
+			Expect(provisioner).To(ContainFile(ctx, file))
 		})
 	})
 
@@ -279,6 +279,7 @@ var _ = Describe("Command Resources", func() {
 				}),
 				Hook: func(inputs, output resource.PropertyMap) {
 					Expect(output["stderr"]).To(HavePropertyValue(""))
+					Expect(output["stdout"]).To(HavePropertyValue(""))
 					Expect(provisioner).NotTo(ContainFile(context.Background(), file))
 				},
 				ExpectedOutput: resource.NewPropertyMapFromMap(map[string]interface{}{
@@ -346,59 +347,16 @@ var _ = Describe("Command Resources", func() {
 					},
 				}),
 				Hook: func(inputs, output resource.PropertyMap) {
+					Expect(output["exitCode"]).To(HavePropertyValue(0))
 					Expect(output["stderr"]).To(HavePropertyValue(""))
+					Expect(output["stdout"]).To(HavePropertyValue(""))
+					Expect(output["createdFiles"]).To(Equal(resource.NewArrayProperty([]resource.PropertyValue{
+						resource.NewProperty(expectedFile),
+					})))
+					Expect(output["movedFiles"].V).To(Equal(resource.PropertyMap{}))
+					Expect(output["args"].V).To(Equal(inputs["args"].V))
 					Expect(provisioner).To(ContainFile(context.Background(), expectedFile))
 				},
-				ExpectedOutput: resource.NewPropertyMapFromMap(map[string]interface{}{
-					"exitCode":     0,
-					"stdout":       "",
-					"stderr":       "",
-					"createdFiles": []string{expectedFile},
-					"movedFiles":   map[string]string{},
-					"args": map[string]interface{}{
-						"extract":   true,
-						"file":      archive,
-						"directory": dest,
-						"args":      []string{fileName},
-
-						// Defaults
-						"gzip":                 false,
-						"keepDirectorySymlink": false,
-						"unlinkFirst":          false,
-						"xz":                   false,
-						"list":                 false,
-						"ignoreCommandError":   false,
-						"excludeFrom":          "",
-						"lzop":                 false,
-						"append":               false,
-						"update":               false,
-						"delete":               false,
-						"excludeVcs":           false,
-						"verbose":              false,
-						"lzip":                 false,
-						"overwriteDir":         false,
-						"transform":            "",
-						"create":               false,
-						"skipOldFiles":         false,
-						"excludeVcsIgnores":    false,
-						"verify":               false,
-						"suffix":               "",
-						"diff":                 false,
-						"exclude":              "",
-						"stripComponents":      0,
-						"bzip2":                false,
-						"keepNewerFiles":       false,
-						"removeFiles":          false,
-						"noSeek":               false,
-						"zstd":                 false,
-						"overwrite":            false,
-						"sparse":               false,
-						"toStdout":             false,
-						"lzma":                 false,
-						"keepOldfiles":         false,
-						"noOverwriteDir":       false,
-					},
-				}),
 			},
 		}
 
@@ -538,8 +496,8 @@ var _ = Describe("Command Resources", func() {
 		It("should complete a full lifecycle", func(ctx context.Context) {
 			run(server, test)
 
-			Expect(provisioner).NotTo(ContainFile(ctx, file))
 			Expect(provisioner).NotTo(ContainFile(ctx, newFile))
+			Expect(provisioner).NotTo(ContainFile(ctx, file))
 		})
 	})
 

--- a/tests/provider_suite_test.go
+++ b/tests/provider_suite_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,7 +14,6 @@ var (
 	provisioner util.TestProvisioner
 	sshServer   util.SshServer
 	clientCerts *util.CertBundle
-	logFile     *os.File
 )
 
 func TestProvider(t *testing.T) {
@@ -24,18 +22,14 @@ func TestProvider(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(ctx context.Context) {
-	_ = os.Mkdir("out", os.ModePerm)
-
-	l, err := os.Create("out/log.txt")
-	Expect(err).NotTo(HaveOccurred())
-	logFile = l
+	var err error
 
 	By("generating client certs")
 	clientCerts, err = util.NewCertBundle("ca", "pulumi")
 	Expect(err).NotTo(HaveOccurred())
 
 	By("creating a provisioner")
-	prov, err := util.NewProvisioner("6969", clientCerts.Ca, logFile)
+	prov, err := util.NewProvisioner("6969", clientCerts.Ca, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("starting the provisioner")
@@ -57,11 +51,6 @@ var _ = AfterSuite(func(ctx context.Context) {
 	if provisioner != nil {
 		By("stopping the provisioner")
 		err := provisioner.Stop(ctx)
-		Expect(err).NotTo(HaveOccurred())
-	}
-
-	if logFile != nil {
-		err := logFile.Close()
 		Expect(err).NotTo(HaveOccurred())
 	}
 

--- a/tests/provider_suite_test.go
+++ b/tests/provider_suite_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,6 +15,7 @@ var (
 	provisioner util.TestProvisioner
 	sshServer   util.SshServer
 	clientCerts *util.CertBundle
+	logFile     *os.File
 )
 
 func TestProvider(t *testing.T) {
@@ -22,14 +24,18 @@ func TestProvider(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(ctx context.Context) {
-	var err error
+	_ = os.Mkdir("out", os.ModePerm)
+
+	l, err := os.Create("out/log.txt")
+	Expect(err).NotTo(HaveOccurred())
+	logFile = l
 
 	By("generating client certs")
 	clientCerts, err = util.NewCertBundle("ca", "pulumi")
 	Expect(err).NotTo(HaveOccurred())
 
 	By("creating a provisioner")
-	prov, err := util.NewProvisioner("6969", clientCerts.Ca, GinkgoWriter)
+	prov, err := util.NewProvisioner("6969", clientCerts.Ca, logFile)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("starting the provisioner")
@@ -51,6 +57,11 @@ var _ = AfterSuite(func(ctx context.Context) {
 	if provisioner != nil {
 		By("stopping the provisioner")
 		err := provisioner.Stop(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	if logFile != nil {
+		err := logFile.Close()
 		Expect(err).NotTo(HaveOccurred())
 	}
 

--- a/tests/util/provisioner.go
+++ b/tests/util/provisioner.go
@@ -53,6 +53,9 @@ func NewProvisioner(
 				{ContainerFilePath: certPath, Reader: bytes.NewReader(certs.Cert.Bytes)},
 				{ContainerFilePath: keyPath, Reader: bytes.NewReader(certs.Cert.KeyBytes)},
 			},
+			Env: map[string]string{
+				"GRPC_GO_LOG_SEVERITY_LEVEL": "info",
+			},
 			Cmd: []string{
 				"--network", defaultProtocol,
 				"--address", fmt.Sprintf("%s:%s", "0.0.0.0", port),


### PR DESCRIPTION
Enhanced the test suite by adding a log file creation process in the provider_suite_test.go. Also, updated the provisioner to include an environment variable for GRPC logging level. In lifecycle_test.go, added another update operation to move files from one location to another, increasing the complexity of tests.