### PR TITLE
Accept tee stdin via string once again

### DIFF
--- a/provider/pkg/provider/cmd/args.go
+++ b/provider/pkg/provider/cmd/args.go
@@ -12,7 +12,7 @@ type CommandArgs[T Builder] struct {
 	CustomDelete []string `pulumi:"customDelete,optional"`
 }
 
-func (a *CommandArgs[T]) Cmd() *pb.Command {
+func (a *CommandArgs[T]) Cmd() (*pb.Command, error) {
 	return a.Args.Cmd()
 }
 

--- a/provider/pkg/provider/cmd/builder.go
+++ b/provider/pkg/provider/cmd/builder.go
@@ -4,7 +4,7 @@ import pb "github.com/unmango/pulumi-baremetal/gen/go/unmango/baremetal/v1alpha1
 
 type Builder interface {
 	FsManipulator
-	Cmd() *pb.Command
+	Cmd() (*pb.Command, error)
 }
 
 type B struct {

--- a/provider/pkg/provider/cmd/create.go
+++ b/provider/pkg/provider/cmd/create.go
@@ -17,6 +17,12 @@ func (s *State[T]) Create(ctx context.Context, inputs CommandArgs[T], preview bo
 		return nil
 	}
 
+	command, err := inputs.Cmd()
+	if err != nil {
+		log.Errorf("Failed constructing command: %s", err)
+		return err
+	}
+
 	p, err := provisioner.FromContext(ctx)
 	if err != nil {
 		log.Error("failed creating provisioner")
@@ -25,7 +31,7 @@ func (s *State[T]) Create(ctx context.Context, inputs CommandArgs[T], preview bo
 
 	log.InfoStatus("Sending create request to provisioner")
 	res, err := p.Create(ctx, &pb.CreateRequest{
-		Command:       inputs.Cmd(),
+		Command:       command,
 		ExpectCreated: inputs.ExpectCreated(),
 		ExpectMoved:   inputs.ExpectMoved(),
 	})

--- a/provider/pkg/provider/cmd/delete.go
+++ b/provider/pkg/provider/cmd/delete.go
@@ -28,19 +28,16 @@ func (s *State[T]) Delete(ctx context.Context) error {
 		log.InfoStatus("Normal delete")
 	}
 
+	prev, err := s.Operation()
+	if err != nil {
+		log.Errorf("Failed generating operation from state: %s", err)
+		return fmt.Errorf("failed to generate operation from state: %w", err)
+	}
+
 	log.InfoStatus("Sending delete request to provisioner")
 	res, err := p.Delete(ctx, &pb.DeleteRequest{
-		Command: command,
-		Previous: &pb.Operation{
-			Command:      s.Cmd(),
-			CreatedFiles: s.CreatedFiles,
-			MovedFiles:   s.MovedFiles,
-			Result: &pb.Result{
-				ExitCode: int32(s.ExitCode),
-				Stdout:   s.Stdout,
-				Stderr:   s.Stderr,
-			},
-		},
+		Command:  command,
+		Previous: prev,
 	})
 	if err != nil {
 		return fmt.Errorf("sending delete request: %w", err)

--- a/provider/pkg/provider/cmd/state.go
+++ b/provider/pkg/provider/cmd/state.go
@@ -1,5 +1,11 @@
 package cmd
 
+import (
+	"fmt"
+
+	pb "github.com/unmango/pulumi-baremetal/gen/go/unmango/baremetal/v1alpha1"
+)
+
 type State[T Builder] struct {
 	CommandArgs[T]
 
@@ -19,4 +25,22 @@ func (s *State[T]) Copy() State[T] {
 		CreatedFiles: s.CreatedFiles,
 		MovedFiles:   s.MovedFiles,
 	}
+}
+
+func (s *State[T]) Operation() (*pb.Operation, error) {
+	command, err := s.Cmd()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build command from state; %w", err)
+	}
+
+	return &pb.Operation{
+		Command:      command,
+		CreatedFiles: s.CreatedFiles,
+		MovedFiles:   s.MovedFiles,
+		Result: &pb.Result{
+			ExitCode: int32(s.ExitCode),
+			Stdout:   s.Stdout,
+			Stderr:   s.Stderr,
+		},
+	}, nil
 }

--- a/provider/pkg/provider/coreutils/chmod.go
+++ b/provider/pkg/provider/coreutils/chmod.go
@@ -28,7 +28,7 @@ type ChmodArgs struct {
 }
 
 // Cmd implements CommandArgs.
-func (m ChmodArgs) Cmd() *pb.Command {
+func (m ChmodArgs) Cmd() (*pb.Command, error) {
 	b := cmd.B{}
 	b.Op(m.Changes, "--changes")
 	b.Op(m.NoPreserveRoot, "--no-preserve-root")
@@ -50,7 +50,7 @@ func (m ChmodArgs) Cmd() *pb.Command {
 	return &pb.Command{
 		Bin:  pb.Bin_BIN_CHMOD,
 		Args: b.Args,
-	}
+	}, nil
 }
 
 var _ cmd.Builder = ChmodArgs{}

--- a/provider/pkg/provider/coreutils/mkdir.go
+++ b/provider/pkg/provider/coreutils/mkdir.go
@@ -21,7 +21,7 @@ type MkdirArgs struct {
 }
 
 // Cmd implements CommandArgs.
-func (m MkdirArgs) Cmd() *pb.Command {
+func (m MkdirArgs) Cmd() (*pb.Command, error) {
 	b := cmd.B{Args: m.Directory}
 
 	b.Opv(m.Mode, "--mode")
@@ -33,7 +33,7 @@ func (m MkdirArgs) Cmd() *pb.Command {
 	return &pb.Command{
 		Bin:  pb.Bin_BIN_MKDIR,
 		Args: b.Args,
-	}
+	}, nil
 }
 
 var _ cmd.Builder = MkdirArgs{}

--- a/provider/pkg/provider/coreutils/mktemp.go
+++ b/provider/pkg/provider/coreutils/mktemp.go
@@ -26,7 +26,7 @@ type MktempArgs struct {
 }
 
 // Cmd implements CommandArgs.
-func (m MktempArgs) Cmd() *pb.Command {
+func (m MktempArgs) Cmd() (*pb.Command, error) {
 	b := cmd.B{}
 
 	b.Op(m.Directory, "--directory")
@@ -46,7 +46,7 @@ func (m MktempArgs) Cmd() *pb.Command {
 	return &pb.Command{
 		Bin:  pb.Bin_BIN_MKTEMP,
 		Args: b.Args,
-	}
+	}, nil
 }
 
 var _ cmd.Builder = MktempArgs{}

--- a/provider/pkg/provider/coreutils/mv.go
+++ b/provider/pkg/provider/coreutils/mv.go
@@ -32,7 +32,7 @@ type MvArgs struct {
 }
 
 // Cmd implements CommandArgs.
-func (m MvArgs) Cmd() *pb.Command {
+func (m MvArgs) Cmd() (*pb.Command, error) {
 	b := cmd.B{Args: m.Source}
 
 	b.Opv(m.Backup, "--backup")
@@ -53,7 +53,7 @@ func (m MvArgs) Cmd() *pb.Command {
 	return &pb.Command{
 		Bin:  pb.Bin_BIN_MV,
 		Args: b.Args,
-	}
+	}, nil
 }
 
 // ExpectMoved implements FileManipulator.

--- a/provider/pkg/provider/coreutils/rm.go
+++ b/provider/pkg/provider/coreutils/rm.go
@@ -24,7 +24,7 @@ type RmArgs struct {
 }
 
 // Cmd implements CommandArgs.
-func (r RmArgs) Cmd() *pb.Command {
+func (r RmArgs) Cmd() (*pb.Command, error) {
 	b := cmd.B{Args: r.Files}
 
 	b.Op(r.Dir, "--dir")
@@ -36,7 +36,7 @@ func (r RmArgs) Cmd() *pb.Command {
 	return &pb.Command{
 		Bin:  pb.Bin_BIN_RM,
 		Args: b.Args,
-	}
+	}, nil
 }
 
 var _ cmd.Builder = RmArgs{}

--- a/provider/pkg/provider/coreutils/tar.go
+++ b/provider/pkg/provider/coreutils/tar.go
@@ -77,7 +77,7 @@ type TarArgs struct {
 }
 
 // Cmd implements CommandArgs.
-func (t TarArgs) Cmd() *pb.Command {
+func (t TarArgs) Cmd() (*pb.Command, error) {
 	b := cmd.B{Args: t.Args}
 
 	b.Op(t.Append, "--append")
@@ -126,7 +126,7 @@ func (t TarArgs) Cmd() *pb.Command {
 	return &pb.Command{
 		Bin:  pb.Bin_BIN_TAR,
 		Args: b.Args,
-	}
+	}, nil
 }
 
 // ExpectCreated implements CommandArgs.

--- a/provider/pkg/provider/coreutils/tee.go
+++ b/provider/pkg/provider/coreutils/tee.go
@@ -17,7 +17,7 @@ type TeeArgs struct {
 	cmd.ArgsBase
 
 	Append  bool        `pulumi:"append,optional"`
-	Content asset.Asset `pulumi:"content"`
+	Content asset.Asset `pulumi:"content,optional"`
 	Files   []string    `pulumi:"files"`
 	Stdin   string      `pulumi:"stdin,optional"`
 }
@@ -28,12 +28,17 @@ func (o TeeArgs) Cmd() (*pb.Command, error) {
 		args = append(args, "--append")
 	}
 
-	data, err := o.Content.Bytes()
-	if err != nil {
-		panic(err)
+	var stdin string
+	if len(o.Stdin) > 0 {
+		stdin = o.Stdin
+	} else {
+		data, err := o.Content.Bytes()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read asset bytes: %w", err)
+		}
+		stdin = string(data)
 	}
 
-	stdin := string(data)
 	return &pb.Command{
 		Bin:   pb.Bin_BIN_TEE,
 		Args:  append(args, o.Files...),

--- a/provider/pkg/provider/coreutils/tee.go
+++ b/provider/pkg/provider/coreutils/tee.go
@@ -19,9 +19,10 @@ type TeeArgs struct {
 	Append  bool        `pulumi:"append,optional"`
 	Content asset.Asset `pulumi:"content"`
 	Files   []string    `pulumi:"files"`
+	Stdin   string      `pulumi:"stdin,optional"`
 }
 
-func (o TeeArgs) Cmd() *pb.Command {
+func (o TeeArgs) Cmd() (*pb.Command, error) {
 	args := []string{}
 	if o.Append {
 		args = append(args, "--append")
@@ -37,7 +38,7 @@ func (o TeeArgs) Cmd() *pb.Command {
 		Bin:   pb.Bin_BIN_TEE,
 		Args:  append(args, o.Files...),
 		Stdin: &stdin,
-	}
+	}, nil
 }
 
 // ExpectCreated implements FileManipulator.

--- a/provider/pkg/provider/coreutils/wget.go
+++ b/provider/pkg/provider/coreutils/wget.go
@@ -65,7 +65,7 @@ type WgetArgs struct {
 }
 
 // Cmd implements CommandArgs.
-func (w WgetArgs) Cmd() *pb.Command {
+func (w WgetArgs) Cmd() (*pb.Command, error) {
 	b := &cmd.B{Args: w.Urls}
 
 	b.Opv(w.AppendOutput, "--append-output")
@@ -118,7 +118,7 @@ func (w WgetArgs) Cmd() *pb.Command {
 	return &pb.Command{
 		Bin:  pb.Bin_BIN_WGET,
 		Args: b.Args,
-	}
+	}, nil
 }
 
 // ExpectCreated implements FileManipulator.

--- a/provider/pkg/provider/kubeadm/config/images.go
+++ b/provider/pkg/provider/kubeadm/config/images.go
@@ -38,7 +38,7 @@ type ImagesArgs struct {
 	Rootfs            string            `pulumi:"rootfs,optional"`
 }
 
-func (a ImagesArgs) Cmd() *pb.Command {
+func (a ImagesArgs) Cmd() (*pb.Command, error) {
 	return builder(func(b *cmd.B) {
 		b.Arg("images")
 		b.Arg(string(a.Command))
@@ -48,7 +48,7 @@ func (a ImagesArgs) Cmd() *pb.Command {
 		b.Opv(a.KubernetesVersion, "--kubernetes-version")
 		b.Opv(a.Kubeconfig, "--kubeconfig")
 		b.Opv(a.Rootfs, "--rootfs")
-	})
+	}), nil
 }
 
 type Images struct{}

--- a/provider/pkg/provider/kubeadm/config/images_test.go
+++ b/provider/pkg/provider/kubeadm/config/images_test.go
@@ -12,8 +12,9 @@ var _ = Describe("Images command", func() {
 	It("should properly format arguments", func() {
 		args := config.ImagesArgs{Command: config.Pull}
 
-		cmd := args.Cmd()
+		cmd, err := args.Cmd()
 
+		Expect(err).NotTo(HaveOccurred())
 		Expect(cmd.Bin).To(Equal(pb.Bin_BIN_KUBEADM))
 		Expect(cmd.Args).To(Equal([]string{
 			"config",

--- a/provider/pkg/provider/kubeadm/kubeadm.go
+++ b/provider/pkg/provider/kubeadm/kubeadm.go
@@ -15,12 +15,12 @@ type KubeadmArgs struct {
 	Commands []string `pulumi:"commands"`
 }
 
-func (a KubeadmArgs) Cmd() *pb.Command {
+func (a KubeadmArgs) Cmd() (*pb.Command, error) {
 	return Builder(func(b *cmd.B) {
 		for _, c := range a.Commands {
 			b.Arg(c)
 		}
-	})
+	}), nil
 }
 
 type Kubeadm struct{}

--- a/sdk/dotnet/Coreutils/Inputs/TeeArgsArgs.cs
+++ b/sdk/dotnet/Coreutils/Inputs/TeeArgsArgs.cs
@@ -27,6 +27,9 @@ namespace UnMango.Baremetal.Coreutils.Inputs
             set => _files = value;
         }
 
+        [Input("stdin")]
+        public Input<string>? Stdin { get; set; }
+
         public TeeArgsArgs()
         {
         }

--- a/sdk/dotnet/Coreutils/Inputs/TeeArgsArgs.cs
+++ b/sdk/dotnet/Coreutils/Inputs/TeeArgsArgs.cs
@@ -16,8 +16,8 @@ namespace UnMango.Baremetal.Coreutils.Inputs
         [Input("append")]
         public Input<bool>? Append { get; set; }
 
-        [Input("content", required: true)]
-        public Input<AssetOrArchive> Content { get; set; } = null!;
+        [Input("content")]
+        public Input<AssetOrArchive>? Content { get; set; }
 
         [Input("files", required: true)]
         private InputList<string>? _files;

--- a/sdk/dotnet/Coreutils/Outputs/TeeArgs.cs
+++ b/sdk/dotnet/Coreutils/Outputs/TeeArgs.cs
@@ -15,7 +15,7 @@ namespace UnMango.Baremetal.Coreutils.Outputs
     public sealed class TeeArgs
     {
         public readonly bool? Append;
-        public readonly AssetOrArchive Content;
+        public readonly AssetOrArchive? Content;
         public readonly ImmutableArray<string> Files;
         public readonly string? Stdin;
 
@@ -23,7 +23,7 @@ namespace UnMango.Baremetal.Coreutils.Outputs
         private TeeArgs(
             bool? append,
 
-            AssetOrArchive content,
+            AssetOrArchive? content,
 
             ImmutableArray<string> files,
 

--- a/sdk/dotnet/Coreutils/Outputs/TeeArgs.cs
+++ b/sdk/dotnet/Coreutils/Outputs/TeeArgs.cs
@@ -17,6 +17,7 @@ namespace UnMango.Baremetal.Coreutils.Outputs
         public readonly bool? Append;
         public readonly AssetOrArchive Content;
         public readonly ImmutableArray<string> Files;
+        public readonly string? Stdin;
 
         [OutputConstructor]
         private TeeArgs(
@@ -24,11 +25,14 @@ namespace UnMango.Baremetal.Coreutils.Outputs
 
             AssetOrArchive content,
 
-            ImmutableArray<string> files)
+            ImmutableArray<string> files,
+
+            string? stdin)
         {
             Append = append;
             Content = content;
             Files = files;
+            Stdin = stdin;
         }
     }
 }

--- a/sdk/go/baremetal/coreutils/pulumiTypes.go
+++ b/sdk/go/baremetal/coreutils/pulumiTypes.go
@@ -876,6 +876,7 @@ type TeeArgsType struct {
 	Append  *bool                 `pulumi:"append"`
 	Content pulumi.AssetOrArchive `pulumi:"content"`
 	Files   []string              `pulumi:"files"`
+	Stdin   *string               `pulumi:"stdin"`
 }
 
 // TeeArgsTypeInput is an input type that accepts TeeArgsTypeArgs and TeeArgsTypeOutput values.
@@ -893,6 +894,7 @@ type TeeArgsTypeArgs struct {
 	Append  pulumi.BoolPtrInput        `pulumi:"append"`
 	Content pulumi.AssetOrArchiveInput `pulumi:"content"`
 	Files   pulumi.StringArrayInput    `pulumi:"files"`
+	Stdin   pulumi.StringPtrInput      `pulumi:"stdin"`
 }
 
 func (TeeArgsTypeArgs) ElementType() reflect.Type {
@@ -943,6 +945,10 @@ func (o TeeArgsTypeOutput) Content() pulumi.AssetOrArchiveOutput {
 
 func (o TeeArgsTypeOutput) Files() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v TeeArgsType) []string { return v.Files }).(pulumi.StringArrayOutput)
+}
+
+func (o TeeArgsTypeOutput) Stdin() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TeeArgsType) *string { return v.Stdin }).(pulumi.StringPtrOutput)
 }
 
 type WgetArgsType struct {

--- a/sdk/go/baremetal/x/coreutils/pulumiTypes.go
+++ b/sdk/go/baremetal/x/coreutils/pulumiTypes.go
@@ -801,17 +801,17 @@ func (o TarArgsTypeOutput) Zstd() pulumix.Output[*bool] {
 }
 
 type TeeArgsType struct {
-	Append  *bool                 `pulumi:"append"`
-	Content pulumi.AssetOrArchive `pulumi:"content"`
-	Files   []string              `pulumi:"files"`
-	Stdin   *string               `pulumi:"stdin"`
+	Append  *bool                  `pulumi:"append"`
+	Content *pulumi.AssetOrArchive `pulumi:"content"`
+	Files   []string               `pulumi:"files"`
+	Stdin   *string                `pulumi:"stdin"`
 }
 
 type TeeArgsTypeArgs struct {
-	Append  pulumix.Input[*bool]                 `pulumi:"append"`
-	Content pulumix.Input[pulumi.AssetOrArchive] `pulumi:"content"`
-	Files   pulumix.Input[[]string]              `pulumi:"files"`
-	Stdin   pulumix.Input[*string]               `pulumi:"stdin"`
+	Append  pulumix.Input[*bool]                  `pulumi:"append"`
+	Content pulumix.Input[*pulumi.AssetOrArchive] `pulumi:"content"`
+	Files   pulumix.Input[[]string]               `pulumi:"files"`
+	Stdin   pulumix.Input[*string]                `pulumi:"stdin"`
 }
 
 func (TeeArgsTypeArgs) ElementType() reflect.Type {
@@ -854,8 +854,8 @@ func (o TeeArgsTypeOutput) Append() pulumix.Output[*bool] {
 	return pulumix.Apply[TeeArgsType](o, func(v TeeArgsType) *bool { return v.Append })
 }
 
-func (o TeeArgsTypeOutput) Content() pulumix.Output[pulumi.AssetOrArchive] {
-	return pulumix.Apply[TeeArgsType](o, func(v TeeArgsType) pulumi.AssetOrArchive { return v.Content })
+func (o TeeArgsTypeOutput) Content() pulumix.Output[*pulumi.AssetOrArchive] {
+	return pulumix.Apply[TeeArgsType](o, func(v TeeArgsType) *pulumi.AssetOrArchive { return v.Content })
 }
 
 func (o TeeArgsTypeOutput) Files() pulumix.ArrayOutput[string] {

--- a/sdk/go/baremetal/x/coreutils/pulumiTypes.go
+++ b/sdk/go/baremetal/x/coreutils/pulumiTypes.go
@@ -804,12 +804,14 @@ type TeeArgsType struct {
 	Append  *bool                 `pulumi:"append"`
 	Content pulumi.AssetOrArchive `pulumi:"content"`
 	Files   []string              `pulumi:"files"`
+	Stdin   *string               `pulumi:"stdin"`
 }
 
 type TeeArgsTypeArgs struct {
 	Append  pulumix.Input[*bool]                 `pulumi:"append"`
 	Content pulumix.Input[pulumi.AssetOrArchive] `pulumi:"content"`
 	Files   pulumix.Input[[]string]              `pulumi:"files"`
+	Stdin   pulumix.Input[*string]               `pulumi:"stdin"`
 }
 
 func (TeeArgsTypeArgs) ElementType() reflect.Type {
@@ -859,6 +861,10 @@ func (o TeeArgsTypeOutput) Content() pulumix.Output[pulumi.AssetOrArchive] {
 func (o TeeArgsTypeOutput) Files() pulumix.ArrayOutput[string] {
 	value := pulumix.Apply[TeeArgsType](o, func(v TeeArgsType) []string { return v.Files })
 	return pulumix.ArrayOutput[string]{OutputState: value.OutputState}
+}
+
+func (o TeeArgsTypeOutput) Stdin() pulumix.Output[*string] {
+	return pulumix.Apply[TeeArgsType](o, func(v TeeArgsType) *string { return v.Stdin })
 }
 
 type WgetArgsType struct {

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -116,6 +116,7 @@ export namespace coreutils {
         append?: pulumi.Input<boolean>;
         content: pulumi.Input<pulumi.asset.Asset | pulumi.asset.Archive>;
         files: pulumi.Input<pulumi.Input<string>[]>;
+        stdin?: pulumi.Input<string>;
     }
 
     export interface WgetArgsArgs {

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -114,7 +114,7 @@ export namespace coreutils {
 
     export interface TeeArgsArgs {
         append?: pulumi.Input<boolean>;
-        content: pulumi.Input<pulumi.asset.Asset | pulumi.asset.Archive>;
+        content?: pulumi.Input<pulumi.asset.Asset | pulumi.asset.Archive>;
         files: pulumi.Input<pulumi.Input<string>[]>;
         stdin?: pulumi.Input<string>;
     }

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -116,6 +116,7 @@ export namespace coreutils {
         append?: boolean;
         content: pulumi.asset.Asset | pulumi.asset.Archive;
         files: string[];
+        stdin?: string;
     }
 
     export interface WgetArgs {

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -114,7 +114,7 @@ export namespace coreutils {
 
     export interface TeeArgs {
         append?: boolean;
-        content: pulumi.asset.Asset | pulumi.asset.Archive;
+        content?: pulumi.asset.Asset | pulumi.asset.Archive;
         files: string[];
         stdin?: string;
     }

--- a/sdk/python/unmango_baremetal/coreutils/_inputs.py
+++ b/sdk/python/unmango_baremetal/coreutils/_inputs.py
@@ -1107,11 +1107,14 @@ class TeeArgsArgs:
     def __init__(__self__, *,
                  content: pulumi.Input[Union[pulumi.Asset, pulumi.Archive]],
                  files: pulumi.Input[Sequence[pulumi.Input[str]]],
-                 append: Optional[pulumi.Input[bool]] = None):
+                 append: Optional[pulumi.Input[bool]] = None,
+                 stdin: Optional[pulumi.Input[str]] = None):
         pulumi.set(__self__, "content", content)
         pulumi.set(__self__, "files", files)
         if append is not None:
             pulumi.set(__self__, "append", append)
+        if stdin is not None:
+            pulumi.set(__self__, "stdin", stdin)
 
     @property
     @pulumi.getter
@@ -1139,6 +1142,15 @@ class TeeArgsArgs:
     @append.setter
     def append(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "append", value)
+
+    @property
+    @pulumi.getter
+    def stdin(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "stdin")
+
+    @stdin.setter
+    def stdin(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "stdin", value)
 
 
 @pulumi.input_type

--- a/sdk/python/unmango_baremetal/coreutils/_inputs.py
+++ b/sdk/python/unmango_baremetal/coreutils/_inputs.py
@@ -1105,25 +1105,17 @@ class TarArgsArgs:
 @pulumi.input_type
 class TeeArgsArgs:
     def __init__(__self__, *,
-                 content: pulumi.Input[Union[pulumi.Asset, pulumi.Archive]],
                  files: pulumi.Input[Sequence[pulumi.Input[str]]],
                  append: Optional[pulumi.Input[bool]] = None,
+                 content: Optional[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]] = None,
                  stdin: Optional[pulumi.Input[str]] = None):
-        pulumi.set(__self__, "content", content)
         pulumi.set(__self__, "files", files)
         if append is not None:
             pulumi.set(__self__, "append", append)
+        if content is not None:
+            pulumi.set(__self__, "content", content)
         if stdin is not None:
             pulumi.set(__self__, "stdin", stdin)
-
-    @property
-    @pulumi.getter
-    def content(self) -> pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]:
-        return pulumi.get(self, "content")
-
-    @content.setter
-    def content(self, value: pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]):
-        pulumi.set(self, "content", value)
 
     @property
     @pulumi.getter
@@ -1142,6 +1134,15 @@ class TeeArgsArgs:
     @append.setter
     def append(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "append", value)
+
+    @property
+    @pulumi.getter
+    def content(self) -> Optional[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]:
+        return pulumi.get(self, "content")
+
+    @content.setter
+    def content(self, value: Optional[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]):
+        pulumi.set(self, "content", value)
 
     @property
     @pulumi.getter

--- a/sdk/python/unmango_baremetal/coreutils/outputs.py
+++ b/sdk/python/unmango_baremetal/coreutils/outputs.py
@@ -878,11 +878,14 @@ class TeeArgs(dict):
     def __init__(__self__, *,
                  content: Union[pulumi.Asset, pulumi.Archive],
                  files: Sequence[str],
-                 append: Optional[bool] = None):
+                 append: Optional[bool] = None,
+                 stdin: Optional[str] = None):
         pulumi.set(__self__, "content", content)
         pulumi.set(__self__, "files", files)
         if append is not None:
             pulumi.set(__self__, "append", append)
+        if stdin is not None:
+            pulumi.set(__self__, "stdin", stdin)
 
     @property
     @pulumi.getter
@@ -898,6 +901,11 @@ class TeeArgs(dict):
     @pulumi.getter
     def append(self) -> Optional[bool]:
         return pulumi.get(self, "append")
+
+    @property
+    @pulumi.getter
+    def stdin(self) -> Optional[str]:
+        return pulumi.get(self, "stdin")
 
 
 @pulumi.output_type

--- a/sdk/python/unmango_baremetal/coreutils/outputs.py
+++ b/sdk/python/unmango_baremetal/coreutils/outputs.py
@@ -876,21 +876,17 @@ class TarArgs(dict):
 @pulumi.output_type
 class TeeArgs(dict):
     def __init__(__self__, *,
-                 content: Union[pulumi.Asset, pulumi.Archive],
                  files: Sequence[str],
                  append: Optional[bool] = None,
+                 content: Optional[Union[pulumi.Asset, pulumi.Archive]] = None,
                  stdin: Optional[str] = None):
-        pulumi.set(__self__, "content", content)
         pulumi.set(__self__, "files", files)
         if append is not None:
             pulumi.set(__self__, "append", append)
+        if content is not None:
+            pulumi.set(__self__, "content", content)
         if stdin is not None:
             pulumi.set(__self__, "stdin", stdin)
-
-    @property
-    @pulumi.getter
-    def content(self) -> Union[pulumi.Asset, pulumi.Archive]:
-        return pulumi.get(self, "content")
 
     @property
     @pulumi.getter
@@ -901,6 +897,11 @@ class TeeArgs(dict):
     @pulumi.getter
     def append(self) -> Optional[bool]:
         return pulumi.get(self, "append")
+
+    @property
+    @pulumi.getter
+    def content(self) -> Optional[Union[pulumi.Asset, pulumi.Archive]]:
+        return pulumi.get(self, "content")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
Also adds better error handling for the `CommandBuilder.Cmd()` function
Really struggling with assets in the lifecycle tests