### PR TITLE
Added lib tests to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,4 +321,4 @@ jobs:
         run: make out/install.sh
 
       - name: Test
-        run: make .test/install_script
+        run: make .make/test/install_script

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,11 @@ jobs:
             provider/go.sum
             tests/go.sum
 
+      - name: Lib Tests
+        working-directory: provider
+        run: |
+          go run github.com/onsi/ginkgo/v2/ginkgo run -r -v --silence-skips --github-output
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
A new job has been added to the continuous integration (CI) workflow. This job runs library tests in the 'provider' directory using Ginkgo, a BDD testing framework for Go. The test results are silenced for skipped tests and outputted in a format suitable for GitHub.
